### PR TITLE
Fix(KlasaGuildMemberStore#fetch) Fetching multiple members would error

### DIFF
--- a/src/lib/extensions/KlasaGuildMemberStore.js
+++ b/src/lib/extensions/KlasaGuildMemberStore.js
@@ -6,14 +6,16 @@ const { GuildMemberStore } = require('discord.js');
  */
 class KlasaGuildMemberStore extends GuildMemberStore {
 
-	/**
-	 * Fetches member and syncs settings
-	 * @param  {...any} args d.js args for MemberStore#fetch
-	 */
-	async fetch(...args) {
-		const member = await super.fetch(...args);
+	async _fetchSingle(...args) {
+		const member = await super._fetchSingle(...args);
 		await member.settings.sync();
 		return member;
+	}
+
+	async _fetchMany(...args) {
+		const members = await super._fetchMany(...args);
+		await Promise.all(members.map(member => member.settings.sync()));
+		return members;
 	}
 
 }


### PR DESCRIPTION
### Description of the PR
This PR will fix
```prolog
TypeError: Cannot read property 'sync' of undefined
    at Map.fetch (/home/****/Desktop/highlight/node_modules/klasa-member-gateway/src/lib/extensions/KlasaGuildMemberStore.js:15:25)
```
when doing
```javascript
await guild.members.fetch();
```
GuildMemberStore#fetch actually fetches a single member or many, when no options are passed it will fetch many. this properly does.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)
- Removed `fetch` override and added `_fetchSingle`/`_fetchMany` overrides

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
